### PR TITLE
Use `combineSubtraction` to cutout overlapping sections

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -27,6 +27,7 @@ function App() {
   const [unitWidth, setUnitWidth] = useState(19.05)
   const [unitHeight, setUnitHeight] = useState(19.05)
   const [kerf, setKerf] = useState(0)
+  const [combineCutouts, setCombineCutouts] = useState(false)
 
   useEffect(() => {
 
@@ -44,6 +45,7 @@ function App() {
           unitWidth: new Decimal(unitWidth),
           unitHeight: new Decimal(unitHeight),
           kerf: new Decimal(kerf),
+          combineCutouts: combineCutouts,
         })
 
         const previewSvgData = makerjs.exporter.toSVG(plateData, { stroke: 'white', strokeWidth: '0.5mm', svgAttrs: { width: '100%', height: '100%' } })
@@ -76,7 +78,8 @@ function App() {
     acousticRadius,
     unitWidth,
     unitHeight,
-    kerf
+    kerf,
+    combineCutouts
   ])
 
 
@@ -175,6 +178,15 @@ function App() {
                   <option value="none">None</option>
                   <option value="mx-basic">Cherry MX Basic</option>
                   <option value="mx-extreme">Cherry MX Extreme</option>
+                </Form.Select>
+                <Form.Label>Combine Overlapping Cutouts?</Form.Label>
+                <Form.Select
+                  selected="no"
+                  className="mb-4"
+                  onChange={e => setCombineCutouts(e.target.value === 'yes')}
+                >
+                  <option value="no">No</option>
+                  <option value="yes">Yes</option>
                 </Form.Select>
               </Form>
             </Col>

--- a/src/KLEParser.js
+++ b/src/KLEParser.js
@@ -15,19 +15,23 @@ export function parseKle(kleText) {
     let kleData = null
 
     try {
-        kleData = json5.parse(kleText)
-        console.log("Parsed KLE data as json5: no-bracket (likely from downloaded JSON file")
+        kleData = json5.parse(`[${kleText}]`);
     } catch (error) {
-        console.log("No-bracket was unparseable, trying with brackets added")
+        console.log("data was unparseable, giving up");
+        return null;
+    }
 
-        try {
-            kleData = json5.parse('[' + kleText + ']')
-            console.log("Parsed KLE data as json5: with-bracket (likely pasted from the Raw Data tab)")
-        } catch (error) {
-            console.log("No-bracket was unparseable, giving up")
-            return null
+    // We parse with bracket added, then determine if they were necessary by
+    // seeing how nested the first switch is in.
+    if (kleData.length === 1) {
+        const firstRow = kleData[0];
+        if (firstRow.length > 0) {
+            // "raw" KLE data only has 1 array to represent the row, everything inside that is a flag object or a key string.
+            // So if we see an array here, then we know the provided data was a downloaded JSON file, and we need to extract its row data.
+            if (Array.isArray(firstRow[0])) {
+                kleData = firstRow;
+            }
         }
-
     }
 
 

--- a/src/PlateBuilder.js
+++ b/src/PlateBuilder.js
@@ -25,7 +25,7 @@ import { AcousticMXExtreme } from './cutouts/AcousticMXExtreme'
 export function buildPlate(keysArray, generatorOptions) {
 
 
-    let cutouts = [];
+    let models = {};
     let id = 0
 
     let minX = new Decimal(Number.POSITIVE_INFINITY)
@@ -124,14 +124,14 @@ export function buildPlate(keysArray, generatorOptions) {
         // Render switch
         let switchCutout = makerjs.model.rotate(switchGenerator.generate(key, generatorOptions), key.angle.plus(key.independentSwitchAngle).times(-1).toNumber())
         switchCutout.origin = originNum
-        cutouts.push(switchCutout)
+        models["Switch" + id.toString()] = switchCutout
 
         // Render stabilizer
         let stabilizerCutout = stabilizerGenerator.generate(key, generatorOptions)
         if (stabilizerCutout) {
             stabilizerCutout.origin = originNum
             stabilizerCutout = makerjs.model.rotate(stabilizerCutout, key.angle.plus(key.stabilizerAngle).times(-1).toNumber(), originNum)
-            cutouts.push(stabilizerCutout)
+            models["Stabilizer" + id.toString()] = stabilizerCutout
         }
 
         // Render acoustic cutouts
@@ -139,7 +139,7 @@ export function buildPlate(keysArray, generatorOptions) {
         if (acousticCutout) {
             acousticCutout.origin = originNum
             acousticCutout = makerjs.model.rotate(acousticCutout, key.angle.plus(key.stabilizerAngle).times(-1).toNumber(), originNum)
-            cutouts.push(acousticCutout)
+            models["Acoustic" + id.toString()] = acousticCutout
         }
 
         // TODO: Render acoustic cutouts
@@ -181,10 +181,16 @@ export function buildPlate(keysArray, generatorOptions) {
             lineRight: new makerjs.paths.Line(upperRight, lowerRight)
         }
     }
-    for (const cutout of cutouts) {
-        boundingBox = makerjs.model.combineSubtraction(boundingBox, cutout);
+
+    if (generatorOptions.combineCutouts) {
+        for (let name in models) {
+            const cutout = models[name];
+            boundingBox = makerjs.model.combineSubtraction(boundingBox, cutout);
+        }
+        models = { cutout: boundingBox };
+    } else {
+        models["BoundingBox0"] = boundingBox
     }
 
-    return { models: { boundingBox } }
-
+    return { models }
 }

--- a/src/PlateBuilder.js
+++ b/src/PlateBuilder.js
@@ -25,7 +25,7 @@ import { AcousticMXExtreme } from './cutouts/AcousticMXExtreme'
 export function buildPlate(keysArray, generatorOptions) {
 
 
-    let canvas = { models: {} }
+    let cutouts = [];
     let id = 0
 
     let minX = new Decimal(Number.POSITIVE_INFINITY)
@@ -124,14 +124,14 @@ export function buildPlate(keysArray, generatorOptions) {
         // Render switch
         let switchCutout = makerjs.model.rotate(switchGenerator.generate(key, generatorOptions), key.angle.plus(key.independentSwitchAngle).times(-1).toNumber())
         switchCutout.origin = originNum
-        canvas.models["Switch" + id.toString()] = switchCutout
+        cutouts.push(switchCutout)
 
         // Render stabilizer
         let stabilizerCutout = stabilizerGenerator.generate(key, generatorOptions)
         if (stabilizerCutout) {
             stabilizerCutout.origin = originNum
             stabilizerCutout = makerjs.model.rotate(stabilizerCutout, key.angle.plus(key.stabilizerAngle).times(-1).toNumber(), originNum)
-            canvas.models["Stabilizer" + id.toString()] = stabilizerCutout
+            cutouts.push(stabilizerCutout)
         }
 
         // Render acoustic cutouts
@@ -139,7 +139,7 @@ export function buildPlate(keysArray, generatorOptions) {
         if (acousticCutout) {
             acousticCutout.origin = originNum
             acousticCutout = makerjs.model.rotate(acousticCutout, key.angle.plus(key.stabilizerAngle).times(-1).toNumber(), originNum)
-            canvas.models["Acoustic" + id.toString()] = acousticCutout
+            cutouts.push(acousticCutout)
         }
 
         // TODO: Render acoustic cutouts
@@ -173,7 +173,7 @@ export function buildPlate(keysArray, generatorOptions) {
     let lowerLeft = [minX.toNumber(), minY.times(-1).toNumber()]
     let lowerRight = [maxX.toNumber(), minY.times(-1).toNumber()]
 
-    var boundingBox = {
+    let boundingBox = {
         paths: {
             lineTop: new makerjs.paths.Line(upperLeft, upperRight),
             lineBottom: new makerjs.paths.Line(lowerLeft, lowerRight),
@@ -181,9 +181,10 @@ export function buildPlate(keysArray, generatorOptions) {
             lineRight: new makerjs.paths.Line(upperRight, lowerRight)
         }
     }
+    for (const cutout of cutouts) {
+        boundingBox = makerjs.model.combineSubtraction(boundingBox, cutout);
+    }
 
-    canvas.models["BoundingBox0"] = boundingBox
-
-    return canvas
+    return { models: { boundingBox } }
 
 }


### PR DESCRIPTION
This uses a `makerjs`'s `combineSubtraction` API to combine the overlapping cutouts into a single path. Eg, `[[{x:-1,w:2},""]]` (a 2u stabilizer key) with Cherry MX Spec cutouts goes from:

![cutouts before PR](https://gist.githubusercontent.com/jridgewell/9643cd45245ea6d5846ca79871db2af0/raw/186cf2bb0ad2bac4f8a4de5e5e2b6465df40b6fb/before.svg)

to:

![cutouts after PR](https://gist.githubusercontent.com/jridgewell/9643cd45245ea6d5846ca79871db2af0/raw/186cf2bb0ad2bac4f8a4de5e5e2b6465df40b6fb/after.svg)

This allows the generated DXF file to be imported back into Kicad to generate PCB cutouts.

- - -

I also fixed https://github.com/ai03-2725/yet-another-keyboard-builder/issues/10. There was a type confusion when trying to parse the JSON, a keyboard with a single row looks like a JSON file and we tried to iterate each key as if it were a row.
