### PR TITLE
Add EC cutout generators

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -150,6 +150,8 @@ function App() {
                   <option value="hitek-725">Hi-Tek 725</option>
                   <option value="i-rocks">i-Rocks</option>
                   <option value="futaba-ma">Futaba MA</option>
+                  <option value="ec-generic">EC OEM/Generic</option>
+                  <option value="ec-dynacap">EC DynaCap</option>
 
                 </Form.Select>
                 <Form.Label>Stabilizer Cutout Type</Form.Label>
@@ -163,6 +165,8 @@ function App() {
                   <option value="mx-spec">Cherry MX Spec</option>
                   <option value="alps-aek">Alps AEK</option>
                   <option value="alps-at101">Alps AT101</option>
+                  <option value="ec-generic">EC OEM/Generic</option>
+                  <option value="ec-dynacap">EC DynaCap</option>
                   <option value="none">None</option>
 
                 </Form.Select>

--- a/src/HelpPanes.js
+++ b/src/HelpPanes.js
@@ -3,7 +3,7 @@ export function DataHelpPane() {
     // _rs: Rotate stabilizers independently of the key (useful for bottom row stabs)
     // _rc: Rotate switch cutouts independently of the key
     // _ss: Shift stabilizers (Mainly for 6U off-center). false = Unshifted (default), true = Shifted
-    // _so: Skip automatic orientation fix 
+    // _so: Skip automatic orientation fix
     //      By default, the plategen will auto-rotate vertically tall switches so that they are treated as wide keys rotated 90deg
     //      Setting _so: true will skip this fix
 
@@ -81,7 +81,15 @@ export function SwitchCutoutPane() {
             <h4>Futaba MA</h4>
             <p>14 x 15 mm</p>
             <p>For Futaba MA mechanical switches.</p>
-            
+            <br />
+            <h4>EC OEM/Generic</h4>
+            <p>14.6 x 14 mm</p>
+            <p>For Topre-style, and compatible, EC switches.</p>
+            <br />
+            <h4>EC DynaCap</h4>
+            <p>14.7 x 14.1 mm, rounded 2.075 mm</p>
+            <p>For DynaCap EC switches.</p>
+
         </div>
     )
 }
@@ -108,6 +116,12 @@ export function OtherCutoutPane() {
             <br />
             <h4>Alps AT101</h4>
             <p>Alps-specific stabilizers for AT101 stabilizer sizes.</p>
+            <br />
+            <h4>EC OEM/Generic</h4>
+            <p>Topre-style, and compatible, EC stabilizer sizes.</p>
+            <br />
+            <h4>EC DynaCap</h4>
+            <p>DynaCap EC stabilizer sizes.</p>
             <br />
             <h2>Acoustic Cutout Types</h2>
             <br />

--- a/src/PlateBuilder.js
+++ b/src/PlateBuilder.js
@@ -10,12 +10,16 @@ import { SwitchOmronB3G } from './cutouts/SwitchOmronB3G'
 import { SwitchHiTek725 } from './cutouts/SwitchHiTek725'
 import { SwitchIRocks } from './cutouts/SwitchIRocks'
 import { SwitchFutabaMA } from './cutouts/SwitchFutabaMA'
+import { SwitchECGeneric } from './cutouts/SwitchECGeneric'
+import { SwitchECDynaCap } from './cutouts/SwitchECDynaCap'
 
 import { StabilizerMXBasic } from './cutouts/StabilizerMXBasic'
 import { StabilizerMXSmall } from './cutouts/StabilizerMXSmall'
 import { StabilizerMXSpec } from './cutouts/StabilizerMXSpec'
 import { StabilizerAlpsAEK } from './cutouts/StabilizerAlpsAEK'
 import { StabilizerAlpsAT101 } from './cutouts/StabilizerAlpsAT101'
+import { StabilizerECGeneric } from './cutouts/StabilizerECGeneric'
+import { StabilizerECDynaCap } from './cutouts/StabilizerDynaCap'
 import { NullGenerator } from './cutouts/NullGenerator'
 
 import { AcousticMXBasic } from './cutouts/AcousticMXBasic'
@@ -63,6 +67,13 @@ export function buildPlate(keysArray, generatorOptions) {
         case "futaba-ma":
             switchGenerator = new SwitchFutabaMA();
             break;
+        case "ec-generic":
+            switchGenerator = new SwitchECGeneric();
+            break;
+        case "ec-dynacap":
+            switchGenerator = new SwitchECDynaCap();
+            break;
+
         default:
             console.error("Unsupported switch type")
             return null
@@ -87,6 +98,12 @@ export function buildPlate(keysArray, generatorOptions) {
             break;
         case "none":
             stabilizerGenerator = new NullGenerator();
+            break;
+        case "ec-generic":
+            stabilizerGenerator = new StabilizerECGeneric();
+            break;
+        case "ec-dynacap":
+            stabilizerGenerator = new StabilizerECDynaCap();
             break;
         default:
             console.error("Unsupported stabilizer type")

--- a/src/cutouts/StabilizerDynaCap.js
+++ b/src/cutouts/StabilizerDynaCap.js
@@ -1,0 +1,139 @@
+import Decimal from 'decimal.js'
+import makerjs from 'makerjs'
+import { CutoutGenerator } from './CutoutGenerator'
+
+// Basic MX stabilizer cutout
+
+export class StabilizerECDynaCap extends CutoutGenerator {
+
+    generate(key, generatorOptions) {
+
+        let keySize = key.width
+
+        if (!key.skipOrientationFix && key.height > key.width) {
+            keySize = key.height
+        }
+
+        let stab_spacing_left = null
+        let stab_spacing_right = null
+
+        if (keySize.gte(8)) {
+            stab_spacing_left = stab_spacing_right = new Decimal("66.675")
+        }
+        else if (keySize.gte(7)) {
+            stab_spacing_left = stab_spacing_right = new Decimal("57.15")
+        }
+        else if (keySize.gte(6.25)) {
+            stab_spacing_left = stab_spacing_right = new Decimal("50")
+        }
+        else if (keySize.gte(6)) {
+            if (key.shift6UStabilizers) {
+                stab_spacing_left = new Decimal("57.15")
+                stab_spacing_right = new Decimal("38.1")
+            } else {
+                stab_spacing_left = stab_spacing_right = new Decimal("47.625")
+            }
+        }
+        else if (keySize.gte(3)) {
+            stab_spacing_left = stab_spacing_right = new Decimal("19.05")
+        }
+        else if (keySize.gte(2)) {
+            // do nothing
+        }
+        else {
+            return null
+        }
+
+        let cutouts = null;
+
+        if (stab_spacing_left == null) {
+
+            // OG - hand traced from vendor sch's
+            // const pathData = `M0,7.02
+            //   L11.927,7.02 A1.075,1.075 0 0 0 12.924,6.348 A0.861,0.929 0 0 1 13.785,5.767 L14.65,5.767 A1.425,1.425 0 0 0 16.075,4.342
+            //   L16.075,-3.258 A1.425,1.425 0 0 0 14.638,-4.683 L14.246,-4.683 A1.725,1.725 0 0 1 12.631,-5.803 A1.875,1.875 0 0 0 10.875,-7.02
+            //   L-10.875,-7.02 A1.875,1.875 0 0 0 -12.631,-5.803 A1.725,1.725 0 0 1 -14.246,-4.683 L-14.638,-4.683 A1.425,1.425 0 0 0 -16.075,-3.258
+            //   L-16.075,4.342 A1.425,1.425 0 0 0 -14.65,5.767 L-13.785,5.767 A0.861,0.929 0 0 1 -12.924,6.348 A1.075,1.075 0 0 0 -11.927,7.02
+            //   L0,7.02 Z`
+
+            // Adjusted for 7.05 edges (to fit switch)
+            const pathData = `M0,7.05
+              L11.927,7.05 A1.075,1.075 0 0 0 12.924,6.348 A0.861,0.929 0 0 1 13.785,5.767 L14.65,5.767 A1.425,1.425 0 0 0 16.075,4.342
+              L16.075,-3.258 A1.425,1.425 0 0 0 14.638,-4.683 L14.246,-4.683 A1.725,1.725 0 0 1 12.631,-5.803 A1.875,1.875 0 0 0 10.875,-7.05
+              L-10.875,-7.05 A1.875,1.875 0 0 0 -12.631,-5.803 A1.725,1.725 0 0 1 -14.246,-4.683 L-14.638,-4.683 A1.425,1.425 0 0 0 -16.075,-3.258
+              L-16.075,4.342 A1.425,1.425 0 0 0 -14.65,5.767 L-13.785,5.767 A0.861,0.929 0 0 1 -12.924,6.348 A1.075,1.075 0 0 0 -11.927,7.05
+              L0,7.05 Z`
+
+            const singleCutout = makerjs.model.mirror(makerjs.importer.fromSVGPathData(pathData), false, true)
+
+            singleCutout.paths = singleCutout.paths || {}
+            singleCutout.paths.circle1 = new makerjs.paths.Circle([16.40, -7.208], 1.0)
+            singleCutout.paths.circle2 = new makerjs.paths.Circle([-16.40, -7.208], 1.0)
+
+            const kerf = generatorOptions.kerf.toNumber()
+            cutouts = kerf !== 0
+                ? makerjs.model.outline(singleCutout, Math.abs(kerf), 0, kerf > 0)
+                : singleCutout
+
+        } else {
+
+            const width = new Decimal("13.6")
+            const upperBound = new Decimal("6.95")
+            const lowerBound = new Decimal("-6.95")
+
+            const plusHalfWidth = width.dividedBy(new Decimal("2"))
+            const minsHalfWidth = width.dividedBy(new Decimal("-2"))
+
+            let upperLeft =  [minsHalfWidth.plus(generatorOptions.kerf).toNumber(), upperBound.minus(generatorOptions.kerf).toNumber()]
+            let upperRight = [plusHalfWidth.minus(generatorOptions.kerf).toNumber(), upperBound.minus(generatorOptions.kerf).toNumber()]
+            let lowerLeft =  [minsHalfWidth.plus(generatorOptions.kerf).toNumber(), lowerBound.plus(generatorOptions.kerf).toNumber()]
+            let lowerRight = [plusHalfWidth.minus(generatorOptions.kerf).toNumber(), lowerBound.plus(generatorOptions.kerf).toNumber()]
+
+            var singleCutout = {
+                paths: {
+                    lineTop: new makerjs.paths.Line(upperLeft, upperRight),
+                    lineBottom: new makerjs.paths.Line(lowerLeft, lowerRight),
+                    lineLeft: new makerjs.paths.Line(upperLeft, lowerLeft),
+                    lineRight: new makerjs.paths.Line(upperRight, lowerRight)
+                }
+            }
+
+            if (generatorOptions.stabilizerFilletRadius.gt(0)) {
+
+                // default in filleting options = 0.5, DynaCap stabilizers are 1.075 - overriding as an offset
+                const filletNum = (1.075 - 0.5) + generatorOptions.stabilizerFilletRadius.toNumber()
+
+                var filletTopLeft = makerjs.path.fillet(singleCutout.paths.lineTop, singleCutout.paths.lineLeft, filletNum)
+                var filletTopRight = makerjs.path.fillet(singleCutout.paths.lineTop, singleCutout.paths.lineRight, filletNum)
+                var filletBottomLeft = makerjs.path.fillet(singleCutout.paths.lineBottom, singleCutout.paths.lineLeft, filletNum)
+                var filletBottomRight = makerjs.path.fillet(singleCutout.paths.lineBottom, singleCutout.paths.lineRight, filletNum)
+
+                singleCutout.paths.filletTopLeft = filletTopLeft;
+                singleCutout.paths.filletTopRight = filletTopRight;
+                singleCutout.paths.filletBottomLeft = filletBottomLeft;
+                singleCutout.paths.filletBottomRight = filletBottomRight;
+
+            }
+
+            var cutoutLeft = singleCutout;
+            var cutoutRight = makerjs.model.clone(singleCutout);
+
+            cutoutLeft = makerjs.model.move(cutoutLeft, [stab_spacing_left.times(-1).toNumber(), 0])
+            cutoutRight = makerjs.model.move(cutoutRight, [stab_spacing_right.toNumber(), 0])
+
+            cutouts = {
+                models: {
+                    "left": cutoutLeft,
+                    "right": cutoutRight
+                }
+            }
+
+        }
+
+        if (cutouts && !key.skipOrientationFix && key.height > key.width) {
+            cutouts = makerjs.model.rotate(cutouts, -90)
+        }
+
+        return cutouts;
+    }
+}

--- a/src/cutouts/StabilizerECGeneric.js
+++ b/src/cutouts/StabilizerECGeneric.js
@@ -86,29 +86,6 @@ export class StabilizerECGeneric extends CutoutGenerator {
                 }
             }
 
-            /*
-            // Adjusted for 7.05 edges (to fit switch)
-            const pathData = `M0,7.05
-              L11.927,7.05 A1.075,1.075 0 0 0 12.924,6.348 A0.861,0.929 0 0 1 13.785,5.767 L14.65,5.767 A1.425,1.425 0 0 0 16.075,4.342
-              L16.075,-3.258 A1.425,1.425 0 0 0 14.638,-4.683 L14.246,-4.683 A1.725,1.725 0 0 1 12.631,-5.803 A1.875,1.875 0 0 0 10.875,-7.05
-              L-10.875,-7.05 A1.875,1.875 0 0 0 -12.631,-5.803 A1.725,1.725 0 0 1 -14.246,-4.683 L-14.638,-4.683 A1.425,1.425 0 0 0 -16.075,-3.258
-              L-16.075,4.342 A1.425,1.425 0 0 0 -14.65,5.767 L-13.785,5.767 A0.861,0.929 0 0 1 -12.924,6.348 A1.075,1.075 0 0 0 -11.927,7.05
-              L0,7.05 Z`
-
-            const singleCutout = makerjs.model.mirror(makerjs.importer.fromSVGPathData(pathData), false, true)
-
-
-            singleCutout.paths = singleCutout.paths || {}
-            singleCutout.paths.circle1 = new makerjs.paths.Circle([16.40, -7.208], 1.0)
-            singleCutout.paths.circle2 = new makerjs.paths.Circle([-16.40, -7.208], 1.0)
-
-            const kerf = generatorOptions.kerf.toNumber()
-            cutouts = kerf !== 0
-                ? makerjs.model.outline(singleCutout, Math.abs(kerf), 0, kerf > 0)
-                : singleCutout
-
-            */
-
         } else {
 
             const width = new Decimal("13.6")

--- a/src/cutouts/StabilizerECGeneric.js
+++ b/src/cutouts/StabilizerECGeneric.js
@@ -1,0 +1,173 @@
+import Decimal from 'decimal.js'
+import makerjs from 'makerjs'
+import { CutoutGenerator } from './CutoutGenerator'
+
+// Basic MX stabilizer cutout
+
+export class StabilizerECGeneric extends CutoutGenerator {
+
+    generate(key, generatorOptions) {
+
+        let keySize = key.width
+
+        if (!key.skipOrientationFix && key.height > key.width) {
+            keySize = key.height
+        }
+
+        let stab_spacing_left = null
+        let stab_spacing_right = null
+
+        if (keySize.gte(8)) {
+            stab_spacing_left = stab_spacing_right = new Decimal("66.675")
+        }
+        else if (keySize.gte(7)) {
+            stab_spacing_left = stab_spacing_right = new Decimal("57.15")
+        }
+        else if (keySize.gte(6.25)) {
+            stab_spacing_left = stab_spacing_right = new Decimal("50")
+        }
+        else if (keySize.gte(6)) {
+            if (key.shift6UStabilizers) {
+                stab_spacing_left = new Decimal("57.15")
+                stab_spacing_right = new Decimal("38.1")
+            } else {
+                stab_spacing_left = stab_spacing_right = new Decimal("47.625")
+            }
+        }
+        else if (keySize.gte(3)) {
+            stab_spacing_left = stab_spacing_right = new Decimal("19.05")
+        }
+        else if (keySize.gte(2)) {
+            // do nothing
+        }
+        else {
+            return null
+        }
+
+        let cutouts = null;
+
+        if (stab_spacing_left == null) {
+
+            const pointA = [new Decimal("-16").plus(generatorOptions.kerf).toNumber(), new Decimal("7").minus(generatorOptions.kerf).toNumber()]
+            const pointB = [new Decimal("16").plus(generatorOptions.kerf).toNumber(), new Decimal("7").minus(generatorOptions.kerf).toNumber()]
+            const pointC = [new Decimal("16").plus(generatorOptions.kerf).toNumber(), new Decimal("-5").minus(generatorOptions.kerf).toNumber()]
+            const pointD = [new Decimal("13").plus(generatorOptions.kerf).toNumber(), new Decimal("-7").minus(generatorOptions.kerf).toNumber()]
+            const pointE = [new Decimal("-13").plus(generatorOptions.kerf).toNumber(), new Decimal("-7").minus(generatorOptions.kerf).toNumber()]
+            const pointF = [new Decimal("-16").plus(generatorOptions.kerf).toNumber(), new Decimal("-5").minus(generatorOptions.kerf).toNumber()]
+
+            var singleCutout = {
+                paths: {
+                    line1: new makerjs.paths.Line(pointA, pointB),
+                    line2: new makerjs.paths.Line(pointB, pointC),
+                    line3: new makerjs.paths.Line(pointC, pointD),
+                    line4: new makerjs.paths.Line(pointD, pointE),
+                    line5: new makerjs.paths.Line(pointE, pointF),
+                    line6: new makerjs.paths.Line(pointF, pointA),
+                }
+            }
+
+            if (generatorOptions.stabilizerFilletRadius.gt(0)) {
+                const filletNum = generatorOptions.stabilizerFilletRadius.toNumber()
+
+                singleCutout.paths.fillet1 = makerjs.path.fillet(singleCutout.paths.line1, singleCutout.paths.line2, filletNum)
+                singleCutout.paths.fillet2 = makerjs.path.fillet(singleCutout.paths.line2, singleCutout.paths.line3, filletNum)
+                singleCutout.paths.fillet3 = makerjs.path.fillet(singleCutout.paths.line3, singleCutout.paths.line4, filletNum)
+                singleCutout.paths.fillet4 = makerjs.path.fillet(singleCutout.paths.line4, singleCutout.paths.line5, filletNum)
+                singleCutout.paths.fillet5 = makerjs.path.fillet(singleCutout.paths.line5, singleCutout.paths.line6, filletNum)
+                singleCutout.paths.fillet6 = makerjs.path.fillet(singleCutout.paths.line6, singleCutout.paths.line1, filletNum)
+            }
+
+            singleCutout.paths.circle1 = new makerjs.paths.Circle([16.4, -7.2], 1.0 - generatorOptions.kerf.toNumber())
+            singleCutout.paths.circle2 = new makerjs.paths.Circle([-16.4, -7.2], 1.0 - generatorOptions.kerf.toNumber())
+
+            cutouts = {
+                models: {
+                    "single": singleCutout
+                }
+            }
+
+            /*
+            // Adjusted for 7.05 edges (to fit switch)
+            const pathData = `M0,7.05
+              L11.927,7.05 A1.075,1.075 0 0 0 12.924,6.348 A0.861,0.929 0 0 1 13.785,5.767 L14.65,5.767 A1.425,1.425 0 0 0 16.075,4.342
+              L16.075,-3.258 A1.425,1.425 0 0 0 14.638,-4.683 L14.246,-4.683 A1.725,1.725 0 0 1 12.631,-5.803 A1.875,1.875 0 0 0 10.875,-7.05
+              L-10.875,-7.05 A1.875,1.875 0 0 0 -12.631,-5.803 A1.725,1.725 0 0 1 -14.246,-4.683 L-14.638,-4.683 A1.425,1.425 0 0 0 -16.075,-3.258
+              L-16.075,4.342 A1.425,1.425 0 0 0 -14.65,5.767 L-13.785,5.767 A0.861,0.929 0 0 1 -12.924,6.348 A1.075,1.075 0 0 0 -11.927,7.05
+              L0,7.05 Z`
+
+            const singleCutout = makerjs.model.mirror(makerjs.importer.fromSVGPathData(pathData), false, true)
+
+
+            singleCutout.paths = singleCutout.paths || {}
+            singleCutout.paths.circle1 = new makerjs.paths.Circle([16.40, -7.208], 1.0)
+            singleCutout.paths.circle2 = new makerjs.paths.Circle([-16.40, -7.208], 1.0)
+
+            const kerf = generatorOptions.kerf.toNumber()
+            cutouts = kerf !== 0
+                ? makerjs.model.outline(singleCutout, Math.abs(kerf), 0, kerf > 0)
+                : singleCutout
+
+            */
+
+        } else {
+
+            const width = new Decimal("13.6")
+            const upperBound = new Decimal("6.95")
+            const lowerBound = new Decimal("-6.95")
+
+            const plusHalfWidth = width.dividedBy(new Decimal("2"))
+            const minsHalfWidth = width.dividedBy(new Decimal("-2"))
+
+            let upperLeft =  [minsHalfWidth.plus(generatorOptions.kerf).toNumber(), upperBound.minus(generatorOptions.kerf).toNumber()]
+            let upperRight = [plusHalfWidth.minus(generatorOptions.kerf).toNumber(), upperBound.minus(generatorOptions.kerf).toNumber()]
+            let lowerLeft =  [minsHalfWidth.plus(generatorOptions.kerf).toNumber(), lowerBound.plus(generatorOptions.kerf).toNumber()]
+            let lowerRight = [plusHalfWidth.minus(generatorOptions.kerf).toNumber(), lowerBound.plus(generatorOptions.kerf).toNumber()]
+
+            var singleCutout = {
+                paths: {
+                    lineTop: new makerjs.paths.Line(upperLeft, upperRight),
+                    lineBottom: new makerjs.paths.Line(lowerLeft, lowerRight),
+                    lineLeft: new makerjs.paths.Line(upperLeft, lowerLeft),
+                    lineRight: new makerjs.paths.Line(upperRight, lowerRight)
+                }
+            }
+
+            if (generatorOptions.stabilizerFilletRadius.gt(0)) {
+
+                const filletNum = generatorOptions.stabilizerFilletRadius.toNumber()
+
+                var filletTopLeft = makerjs.path.fillet(singleCutout.paths.lineTop, singleCutout.paths.lineLeft, filletNum)
+                var filletTopRight = makerjs.path.fillet(singleCutout.paths.lineTop, singleCutout.paths.lineRight, filletNum)
+                var filletBottomLeft = makerjs.path.fillet(singleCutout.paths.lineBottom, singleCutout.paths.lineLeft, filletNum)
+                var filletBottomRight = makerjs.path.fillet(singleCutout.paths.lineBottom, singleCutout.paths.lineRight, filletNum)
+
+                singleCutout.paths.filletTopLeft = filletTopLeft;
+                singleCutout.paths.filletTopRight = filletTopRight;
+                singleCutout.paths.filletBottomLeft = filletBottomLeft;
+                singleCutout.paths.filletBottomRight = filletBottomRight;
+
+            }
+
+            var cutoutLeft = singleCutout;
+            var cutoutRight = makerjs.model.clone(singleCutout);
+
+            cutoutLeft = makerjs.model.move(cutoutLeft, [stab_spacing_left.times(-1).toNumber(), 0])
+            cutoutRight = makerjs.model.move(cutoutRight, [stab_spacing_right.toNumber(), 0])
+
+            cutouts = {
+                models: {
+                    "left": cutoutLeft,
+                    "right": cutoutRight
+                }
+            }
+
+        }
+
+        if (cutouts && !key.skipOrientationFix && key.height > key.width) {
+            cutouts = makerjs.model.rotate(cutouts, -90)
+        }
+
+        return cutouts;
+    }
+
+}

--- a/src/cutouts/StabilizerECGeneric.js
+++ b/src/cutouts/StabilizerECGeneric.js
@@ -55,7 +55,7 @@ export class StabilizerECGeneric extends CutoutGenerator {
             const pointE = [new Decimal("-13").plus(generatorOptions.kerf).toNumber(), new Decimal("-7").minus(generatorOptions.kerf).toNumber()]
             const pointF = [new Decimal("-16").plus(generatorOptions.kerf).toNumber(), new Decimal("-5").minus(generatorOptions.kerf).toNumber()]
 
-            var singleCutout = {
+            let singleCutout = {
                 paths: {
                     line1: new makerjs.paths.Line(pointA, pointB),
                     line2: new makerjs.paths.Line(pointB, pointC),
@@ -100,7 +100,7 @@ export class StabilizerECGeneric extends CutoutGenerator {
             let lowerLeft =  [minsHalfWidth.plus(generatorOptions.kerf).toNumber(), lowerBound.plus(generatorOptions.kerf).toNumber()]
             let lowerRight = [plusHalfWidth.minus(generatorOptions.kerf).toNumber(), lowerBound.plus(generatorOptions.kerf).toNumber()]
 
-            var singleCutout = {
+            let singleCutout = {
                 paths: {
                     lineTop: new makerjs.paths.Line(upperLeft, upperRight),
                     lineBottom: new makerjs.paths.Line(lowerLeft, lowerRight),

--- a/src/cutouts/SwitchECDynaCap.js
+++ b/src/cutouts/SwitchECDynaCap.js
@@ -1,0 +1,59 @@
+import Decimal from 'decimal.js'
+import makerjs from 'makerjs'
+import { CutoutGenerator } from './CutoutGenerator'
+
+// Basic MX switch cutout
+// Simple filleted square of 14mm size
+
+export class SwitchECDynaCap extends CutoutGenerator {
+
+    generate(key, generatorOptions) {
+
+        const width = new Decimal("14.7")
+        const height = new Decimal("14.1")
+        const plusHalfWidth = width.dividedBy(new Decimal("2"))
+        const minsHalfWidth = width.dividedBy(new Decimal("-2"))
+        const plusHalfHeight = height.dividedBy(new Decimal("2"))
+        const minsHalfHeight = height.dividedBy(new Decimal("-2"))
+
+        let upperLeft =  [minsHalfWidth.plus(generatorOptions.kerf).toNumber(), plusHalfHeight.minus(generatorOptions.kerf).toNumber()]
+        let upperRight = [plusHalfWidth.minus(generatorOptions.kerf).toNumber(), plusHalfHeight.minus(generatorOptions.kerf).toNumber()]
+        let lowerLeft =  [minsHalfWidth.plus(generatorOptions.kerf).toNumber(), minsHalfHeight.plus(generatorOptions.kerf).toNumber()]
+        let lowerRight = [plusHalfWidth.minus(generatorOptions.kerf).toNumber(), minsHalfHeight.plus(generatorOptions.kerf).toNumber()]
+
+        var model = {
+            paths: {
+                lineTop: new makerjs.paths.Line(upperLeft, upperRight),
+                lineBottom: new makerjs.paths.Line(lowerLeft, lowerRight),
+                lineLeft: new makerjs.paths.Line(upperLeft, lowerLeft),
+                lineRight: new makerjs.paths.Line(upperRight, lowerRight)
+            }
+        }
+
+        if (generatorOptions.switchFilletRadius.gt(0)) {
+
+            // default in filleting options = 0.5, DynaCap switches are 2.075 - overriding as an offset
+            const filletNum = (2.075 - 0.5) + generatorOptions.switchFilletRadius.toNumber()
+
+            var filletTopLeft = makerjs.path.fillet(model.paths.lineTop, model.paths.lineLeft, filletNum)
+            var filletTopRight = makerjs.path.fillet(model.paths.lineTop, model.paths.lineRight, filletNum)
+            var filletBottomLeft = makerjs.path.fillet(model.paths.lineBottom, model.paths.lineLeft, filletNum)
+            var filletBottomRight = makerjs.path.fillet(model.paths.lineBottom, model.paths.lineRight, filletNum)
+
+            model.paths.filletTopLeft = filletTopLeft;
+            model.paths.filletTopRight = filletTopRight;
+            model.paths.filletBottomLeft = filletBottomLeft;
+            model.paths.filletBottomRight = filletBottomRight;
+        }
+
+        // // Not sure these should be added as they are seldom used
+        // model.paths.circle1 = new makerjs.paths.Circle([9.525, 0], 1.0)
+        // model.paths.circle2 = new makerjs.paths.Circle([-9.525, 0], 1.0)
+
+        if (!key.skipOrientationFix && key.height > key.width) {
+            model = makerjs.model.rotate(model, -90)
+        }
+
+        return model;
+    }
+}

--- a/src/cutouts/SwitchECGeneric.js
+++ b/src/cutouts/SwitchECGeneric.js
@@ -1,0 +1,55 @@
+import Decimal from 'decimal.js'
+import makerjs from 'makerjs'
+import { CutoutGenerator } from './CutoutGenerator'
+
+// Basic MX switch cutout
+// Simple filleted square of 14mm size
+
+export class SwitchECGeneric extends CutoutGenerator {
+
+    generate(key, generatorOptions) {
+
+        const width = new Decimal("14.6")
+        const height = new Decimal("14.0")
+        const plusHalfWidth = width.dividedBy(new Decimal("2"))
+        const minsHalfWidth = width.dividedBy(new Decimal("-2"))
+        const plusHalfHeight = height.dividedBy(new Decimal("2"))
+        const minsHalfHeight = height.dividedBy(new Decimal("-2"))
+
+        let upperLeft =  [minsHalfWidth.plus(generatorOptions.kerf).toNumber(), plusHalfHeight.minus(generatorOptions.kerf).toNumber()]
+        let upperRight = [plusHalfWidth.minus(generatorOptions.kerf).toNumber(), plusHalfHeight.minus(generatorOptions.kerf).toNumber()]
+        let lowerLeft =  [minsHalfWidth.plus(generatorOptions.kerf).toNumber(), minsHalfHeight.plus(generatorOptions.kerf).toNumber()]
+        let lowerRight = [plusHalfWidth.minus(generatorOptions.kerf).toNumber(), minsHalfHeight.plus(generatorOptions.kerf).toNumber()]
+
+        var model = {
+            paths: {
+                lineTop: new makerjs.paths.Line(upperLeft, upperRight),
+                lineBottom: new makerjs.paths.Line(lowerLeft, lowerRight),
+                lineLeft: new makerjs.paths.Line(upperLeft, lowerLeft),
+                lineRight: new makerjs.paths.Line(upperRight, lowerRight)
+            }
+        }
+
+        if (generatorOptions.switchFilletRadius.gt(0)) {
+
+            const filletNum = generatorOptions.switchFilletRadius.toNumber()
+
+            var filletTopLeft = makerjs.path.fillet(model.paths.lineTop, model.paths.lineLeft, filletNum)
+            var filletTopRight = makerjs.path.fillet(model.paths.lineTop, model.paths.lineRight, filletNum)
+            var filletBottomLeft = makerjs.path.fillet(model.paths.lineBottom, model.paths.lineLeft, filletNum)
+            var filletBottomRight = makerjs.path.fillet(model.paths.lineBottom, model.paths.lineRight, filletNum)
+
+            model.paths.filletTopLeft = filletTopLeft;
+            model.paths.filletTopRight = filletTopRight;
+            model.paths.filletBottomLeft = filletBottomLeft;
+            model.paths.filletBottomRight = filletBottomRight;
+
+        }
+
+        if (!key.skipOrientationFix && key.height > key.width) {
+            model = makerjs.model.rotate(model, -90)
+        }
+
+        return model;
+    }
+}


### PR DESCRIPTION
This PR is to address #6.  i.e. Adding support for Topre-like and DynaCap EC switch pate cuts.
I am aware that there is already a generator of this type of cutout, but the static DXF from there do not fully close the 2U stab cutouts, leaving the import of the DXF with much editing to do.

This code uses the existing code structure to replicate the cutouts exactly as that reference does, but within this generator.

Both Topre-like (Niz/Deskeys/Navies) and DynaCap are supported.

As example, the following KLE will render:

```json
["",{"w":2},""],
[{"w":3},""]
```

<img width="762" height="572" alt="image" src="https://github.com/user-attachments/assets/79f1f960-794e-44c5-afc8-90a043fcfe24" />

for "OEM/Generic", and
    
<img width="764" height="564" alt="image" src="https://github.com/user-attachments/assets/f8c5c465-6d06-4561-94f6-cbb457c2e587" />

for "EC DynaCap"