### PR TITLE
Minor fix to MX Spec Stabilizer filleting

### DIFF
--- a/src/cutouts/StabilizerMXSpec.js
+++ b/src/cutouts/StabilizerMXSpec.js
@@ -112,27 +112,27 @@ export class StabilizerMXSpec extends CutoutGenerator {
         if (generatorOptions.stabilizerFilletRadius.gt(0)) {
 
             const filletNum = generatorOptions.stabilizerFilletRadius.toNumber()
-            const filletNum_A = new Decimal( Math.min(filletNum, (4.191-3.3274-0.001) - filletNum) ).toNumber()
-            const filletNum_B = new Decimal( Math.min(filletNum, (7.7724-6.604-0.001) - filletNum) ).toNumber()
-
-            console.debug(`A = ${filletNum_A}`)
-            console.debug(`B = ${filletNum_B}`)
+            const TOLERANCE = 0.002
+            const filletNum2a = new Decimal( Math.min(filletNum, (Math.abs(pointW[1] - pointB[1]) - TOLERANCE) - filletNum) ).toNumber()
+            const filletNum2d = new Decimal( Math.min(filletNum, (Math.abs(pointC[1] - pointZ[1]) - TOLERANCE) - filletNum) ).toNumber()
+            const filletNum4 = keySize.lte(3) ? new Decimal(Math.min(filletNum, (1.1684 - TOLERANCE) - filletNum)).toNumber() : filletNum;
+            const filletNum9 = keySize.lte(3) ? new Decimal(Math.min(filletNum, (0.8636 - TOLERANCE) - filletNum)).toNumber() : filletNum;
 
             for (let currCutout of [cutoutLeft, cutoutRight]) {
 
                 var fillet1 = makerjs.path.fillet(currCutout.paths.line1, currCutout.paths.line2a, filletNum)
-                var fillet1a = makerjs.path.fillet(currCutout.paths.line2a, currCutout.paths.line2b, filletNum)
-                var fillet1b = makerjs.path.fillet(currCutout.paths.line2c, currCutout.paths.line2d, filletNum)
+                var fillet1a = makerjs.path.fillet(currCutout.paths.line2a, currCutout.paths.line2b, filletNum2a)
+                var fillet1b = makerjs.path.fillet(currCutout.paths.line2c, currCutout.paths.line2d, filletNum2d)
                 var fillet2 = makerjs.path.fillet(currCutout.paths.line2d, currCutout.paths.line3, filletNum)
-                var fillet3 = makerjs.path.fillet(currCutout.paths.line3, currCutout.paths.line4, filletNum_B)
+                var fillet3 = makerjs.path.fillet(currCutout.paths.line3, currCutout.paths.line4, filletNum4)
                 var fillet4 = makerjs.path.fillet(currCutout.paths.line4, currCutout.paths.line5, filletNum)
                 var fillet5 = makerjs.path.fillet(currCutout.paths.line5, currCutout.paths.line6, filletNum)
-                var fillet6 = makerjs.path.fillet(currCutout.paths.line6, currCutout.paths.line7, filletNum_B)
+                var fillet6 = makerjs.path.fillet(currCutout.paths.line6, currCutout.paths.line7, filletNum4)
                 var fillet7 = makerjs.path.fillet(currCutout.paths.line7, currCutout.paths.line8, filletNum)
-                var fillet8 = makerjs.path.fillet(currCutout.paths.line8, currCutout.paths.line9, filletNum_A)
+                var fillet8 = makerjs.path.fillet(currCutout.paths.line8, currCutout.paths.line9, filletNum9)
                 var fillet9 = makerjs.path.fillet(currCutout.paths.line9, currCutout.paths.line10, filletNum)
                 var fillet10 = makerjs.path.fillet(currCutout.paths.line10, currCutout.paths.line11, filletNum)
-                var fillet11 = makerjs.path.fillet(currCutout.paths.line11, currCutout.paths.line12, filletNum_A)
+                var fillet11 = makerjs.path.fillet(currCutout.paths.line11, currCutout.paths.line12, filletNum9)
                 var fillet12 = makerjs.path.fillet(currCutout.paths.line12, currCutout.paths.line1, filletNum)
 
                 currCutout.paths.fillet1 = fillet1;
@@ -149,7 +149,6 @@ export class StabilizerMXSpec extends CutoutGenerator {
                 currCutout.paths.fillet10 = fillet10;
                 currCutout.paths.fillet11 = fillet11;
                 currCutout.paths.fillet12 = fillet12;
-
             }
 
         }

--- a/src/cutouts/StabilizerMXSpec.js
+++ b/src/cutouts/StabilizerMXSpec.js
@@ -59,7 +59,6 @@ export class StabilizerMXSpec extends CutoutGenerator {
         const pointK = [new Decimal("-4.191").plus(generatorOptions.kerf).toNumber(), new Decimal("2.286").minus(generatorOptions.kerf).toNumber()]
         const pointL = [new Decimal("-3.3274").plus(generatorOptions.kerf).toNumber(), new Decimal("2.286").minus(generatorOptions.kerf).toNumber()]
 
-
         // The "entry point" for the bar horizontal cutout bit
         let pointW, pointXL, pointXR, pointYL, pointYR, pointZ;
 
@@ -113,6 +112,11 @@ export class StabilizerMXSpec extends CutoutGenerator {
         if (generatorOptions.stabilizerFilletRadius.gt(0)) {
 
             const filletNum = generatorOptions.stabilizerFilletRadius.toNumber()
+            const filletNum_A = new Decimal( Math.min(filletNum, (4.191-3.3274-0.001) - filletNum) ).toNumber()
+            const filletNum_B = new Decimal( Math.min(filletNum, (7.7724-6.604-0.001) - filletNum) ).toNumber()
+
+            console.debug(`A = ${filletNum_A}`)
+            console.debug(`B = ${filletNum_B}`)
 
             for (let currCutout of [cutoutLeft, cutoutRight]) {
 
@@ -120,15 +124,15 @@ export class StabilizerMXSpec extends CutoutGenerator {
                 var fillet1a = makerjs.path.fillet(currCutout.paths.line2a, currCutout.paths.line2b, filletNum)
                 var fillet1b = makerjs.path.fillet(currCutout.paths.line2c, currCutout.paths.line2d, filletNum)
                 var fillet2 = makerjs.path.fillet(currCutout.paths.line2d, currCutout.paths.line3, filletNum)
-                var fillet3 = makerjs.path.fillet(currCutout.paths.line3, currCutout.paths.line4, filletNum)
+                var fillet3 = makerjs.path.fillet(currCutout.paths.line3, currCutout.paths.line4, filletNum_B)
                 var fillet4 = makerjs.path.fillet(currCutout.paths.line4, currCutout.paths.line5, filletNum)
                 var fillet5 = makerjs.path.fillet(currCutout.paths.line5, currCutout.paths.line6, filletNum)
-                var fillet6 = makerjs.path.fillet(currCutout.paths.line6, currCutout.paths.line7, filletNum)
+                var fillet6 = makerjs.path.fillet(currCutout.paths.line6, currCutout.paths.line7, filletNum_B)
                 var fillet7 = makerjs.path.fillet(currCutout.paths.line7, currCutout.paths.line8, filletNum)
-                var fillet8 = makerjs.path.fillet(currCutout.paths.line8, currCutout.paths.line9, filletNum)
+                var fillet8 = makerjs.path.fillet(currCutout.paths.line8, currCutout.paths.line9, filletNum_A)
                 var fillet9 = makerjs.path.fillet(currCutout.paths.line9, currCutout.paths.line10, filletNum)
                 var fillet10 = makerjs.path.fillet(currCutout.paths.line10, currCutout.paths.line11, filletNum)
-                var fillet11 = makerjs.path.fillet(currCutout.paths.line11, currCutout.paths.line12, filletNum)
+                var fillet11 = makerjs.path.fillet(currCutout.paths.line11, currCutout.paths.line12, filletNum_A)
                 var fillet12 = makerjs.path.fillet(currCutout.paths.line12, currCutout.paths.line1, filletNum)
 
                 currCutout.paths.fillet1 = fillet1;
@@ -149,7 +153,6 @@ export class StabilizerMXSpec extends CutoutGenerator {
             }
 
         }
-
 
         cutoutLeft = makerjs.model.move(cutoutLeft, [stab_spacing_left.times(-1).toNumber(), 0])
         cutoutRight = makerjs.model.move(cutoutRight, [stab_spacing_right.toNumber(), 0])


### PR DESCRIPTION
Currently the generator generates a oddity with the MX Spec Stabilizer, in that some of the filleting renders silent errors and produces odd shapes that may cause milling issues.  This is a quirk of MakerJS.

To be fair, the spec does state to use 0.2 mm filleting - but the generator defaults to 0.5 mm.  Some users may not adjust to the correct filleting size rendering the following (as example) cutout:

<img width="437" height="294" alt="image" src="https://github.com/user-attachments/assets/0a62132e-7103-40d7-904a-19c97d4fc652" />
   
   
(With the correct 0.2mm filleting set, this does not occur.)

<img width="442" height="295" alt="image" src="https://github.com/user-attachments/assets/013881bf-dcee-4b88-abb7-a9816c6859ea" />
    
    
With this patch the outer edges fillet to the MIN() value of the wanted fillet size, or the distance remaining on the shortest line. 

<img width="434" height="287" alt="image" src="https://github.com/user-attachments/assets/5e5a5de2-1e54-46bc-a98f-6d5fb6d7af06" />
