### PR TITLE
Add Japan JIS / JLA-425/450 spec 4.25 & 4.5 stab sizes

### DIFF
--- a/src/cutouts/StabilizerMXBasic.js
+++ b/src/cutouts/StabilizerMXBasic.js
@@ -12,11 +12,11 @@ export class StabilizerMXBasic extends CutoutGenerator {
 
         if (!key.skipOrientationFix && key.height > key.width) {
             keySize = key.height
-        } 
+        }
 
         let stab_spacing_left = null
         let stab_spacing_right = null
-        
+
         if (keySize.gte(8)) {
             stab_spacing_left = stab_spacing_right = new Decimal("66.675")
         }
@@ -34,6 +34,12 @@ export class StabilizerMXBasic extends CutoutGenerator {
                 stab_spacing_left = stab_spacing_right = new Decimal("47.625")
             }
         }
+        else if (keySize.gte(4.5)) {
+            stab_spacing_left = stab_spacing_right = new Decimal("35")
+        }
+        else if (keySize.gte(4.25)) {
+            stab_spacing_left = stab_spacing_right = new Decimal("30")
+        }
         else if (keySize.gte(3)) {
             stab_spacing_left = stab_spacing_right = new Decimal("19.05")
         }
@@ -50,7 +56,7 @@ export class StabilizerMXBasic extends CutoutGenerator {
 
         const plusHalfWidth = width.dividedBy(new Decimal("2"))
         const minsHalfWidth = width.dividedBy(new Decimal("-2"))
-        
+
         let upperLeft =  [minsHalfWidth.plus(generatorOptions.kerf).toNumber(), upperBound.minus(generatorOptions.kerf).toNumber()]
         let upperRight = [plusHalfWidth.minus(generatorOptions.kerf).toNumber(), upperBound.minus(generatorOptions.kerf).toNumber()]
         let lowerLeft =  [minsHalfWidth.plus(generatorOptions.kerf).toNumber(), lowerBound.plus(generatorOptions.kerf).toNumber()]
@@ -73,7 +79,7 @@ export class StabilizerMXBasic extends CutoutGenerator {
             var filletTopRight = makerjs.path.fillet(singleCutout.paths.lineTop, singleCutout.paths.lineRight, filletNum)
             var filletBottomLeft = makerjs.path.fillet(singleCutout.paths.lineBottom, singleCutout.paths.lineLeft, filletNum)
             var filletBottomRight = makerjs.path.fillet(singleCutout.paths.lineBottom, singleCutout.paths.lineRight, filletNum)
-            
+
             singleCutout.paths.filletTopLeft = filletTopLeft;
             singleCutout.paths.filletTopRight = filletTopRight;
             singleCutout.paths.filletBottomLeft = filletBottomLeft;
@@ -96,8 +102,8 @@ export class StabilizerMXBasic extends CutoutGenerator {
 
         if (!key.skipOrientationFix && key.height > key.width) {
             cutouts = makerjs.model.rotate(cutouts, -90)
-        } 
-        
+        }
+
         return cutouts;
     }
 }

--- a/src/cutouts/StabilizerMXSmall.js
+++ b/src/cutouts/StabilizerMXSmall.js
@@ -12,11 +12,11 @@ export class StabilizerMXSmall extends CutoutGenerator {
 
         if (!key.skipOrientationFix && key.height > key.width) {
             keySize = key.height
-        } 
+        }
 
         let stab_spacing_left = null
         let stab_spacing_right = null
-        
+
         if (keySize.gte(8)) {
             stab_spacing_left = stab_spacing_right = new Decimal("66.675")
         }
@@ -34,6 +34,12 @@ export class StabilizerMXSmall extends CutoutGenerator {
                 stab_spacing_left = stab_spacing_right = new Decimal("47.625")
             }
         }
+        else if (keySize.gte(4.5)) {
+            stab_spacing_left = stab_spacing_right = new Decimal("35")
+        }
+        else if (keySize.gte(4.25)) {
+            stab_spacing_left = stab_spacing_right = new Decimal("30")
+        }
         else if (keySize.gte(3)) {
             stab_spacing_left = stab_spacing_right = new Decimal("19.05")
         }
@@ -50,7 +56,7 @@ export class StabilizerMXSmall extends CutoutGenerator {
 
         const plusHalfWidth = width.dividedBy(new Decimal("2"))
         const minsHalfWidth = width.dividedBy(new Decimal("-2"))
-        
+
         let upperLeft =  [minsHalfWidth.plus(generatorOptions.kerf).toNumber(), upperBound.minus(generatorOptions.kerf).toNumber()]
         let upperRight = [plusHalfWidth.minus(generatorOptions.kerf).toNumber(), upperBound.minus(generatorOptions.kerf).toNumber()]
         let lowerLeft =  [minsHalfWidth.plus(generatorOptions.kerf).toNumber(), lowerBound.plus(generatorOptions.kerf).toNumber()]
@@ -73,7 +79,7 @@ export class StabilizerMXSmall extends CutoutGenerator {
             var filletTopRight = makerjs.path.fillet(singleCutout.paths.lineTop, singleCutout.paths.lineRight, filletNum)
             var filletBottomLeft = makerjs.path.fillet(singleCutout.paths.lineBottom, singleCutout.paths.lineLeft, filletNum)
             var filletBottomRight = makerjs.path.fillet(singleCutout.paths.lineBottom, singleCutout.paths.lineRight, filletNum)
-            
+
             singleCutout.paths.filletTopLeft = filletTopLeft;
             singleCutout.paths.filletTopRight = filletTopRight;
             singleCutout.paths.filletBottomLeft = filletBottomLeft;
@@ -96,8 +102,8 @@ export class StabilizerMXSmall extends CutoutGenerator {
 
         if (!key.skipOrientationFix && key.height > key.width) {
             cutouts = makerjs.model.rotate(cutouts, -90)
-        } 
-        
+        }
+
         return cutouts;
     }
 }

--- a/src/cutouts/StabilizerMXSpec.js
+++ b/src/cutouts/StabilizerMXSpec.js
@@ -34,6 +34,12 @@ export class StabilizerMXSpec extends CutoutGenerator {
                 stab_spacing_left = stab_spacing_right = new Decimal("47.625")
             }
         }
+        else if (keySize.gte(4.5)) {
+            stab_spacing_left = stab_spacing_right = new Decimal("35")
+        }
+        else if (keySize.gte(4.25)) {
+            stab_spacing_left = stab_spacing_right = new Decimal("30")
+        }
         else if (keySize.gte(3)) {
             stab_spacing_left = stab_spacing_right = new Decimal("19.05")
         }


### PR DESCRIPTION
Fix for #2 .

This is a very simple fix - just adds code `else if`'s on the stab size increments.  Applies the Japan Layout Alliance (JLA) JLA-425 and JLA-450 spec.

To test I've used the following layout:

```json5
[{x:1,w:4},""],
[{x:0.875,w:4.25},""],
[{x:0.75,w:4.5},""],
[{w:6},""]
```

output is:

<img width="195" height="163" alt="image" src="https://github.com/user-attachments/assets/04c38be5-f281-4b7c-a2c0-d42be4c2be98" />·
<img width="195" height="163" alt="image" src="https://github.com/user-attachments/assets/2240247b-b4dc-4d21-ad14-edc39c3f6db6" />

